### PR TITLE
Fix new game vanishing message bug

### DIFF
--- a/diplomacy/web/src/diplomacy/engine/game.js
+++ b/diplomacy/web/src/diplomacy/engine/game.js
@@ -219,6 +219,13 @@ export class Game {
             this.messages.put(Date.now(), message);
             return;
         }
+
+        if (message.gloss) {
+            // don't put the message in the dict at all if it's a gloss
+            // we'll just keep track of it in content_game state
+            return;
+        }
+
         this.messages.put(message.time_sent, message);
     }
 

--- a/diplomacy/web/src/diplomacy/utils/sorted_dict.js
+++ b/diplomacy/web/src/diplomacy/utils/sorted_dict.js
@@ -54,26 +54,11 @@ export class SortedDict {
         key = this.__key_fn(key);
         const position = UTILS.binarySearch.find(this.__keys, key);
 
-        // this feels hacky and awful
-        if (position === -1 && isNaN(key)) {
-            // the glossed messages are passed in with a big unparsed json string
-            // as the key, so it is set as NaN and gets sorted to the top
-            this.clearGloss();
-            return;
-        }
         if (position < 0)
             return null;
         this.__keys.splice(position, 1);
         this.__real_keys.splice(position, 1);
         return this.__values.splice(position, 1)[0];
-    }
-
-    clearGloss() {
-        // just clear the top of the list, because that's where our gloss with
-        // its NaN key will go
-        this.__keys.splice(0, 1);
-        this.__real_keys.splice(0, 1);
-        return this.__values.splice(0, 1)[0];
     }
 
     contains(key) {

--- a/diplomacy/web/src/gui/forms/message_form.jsx
+++ b/diplomacy/web/src/gui/forms/message_form.jsx
@@ -295,7 +295,6 @@ static countries = [
     }
 
     renderEndLocation(){
-        console.log("Engine possible orders with var: ", this.props.engine.possibleOrders[this.state.startLocation], "Var: ", this.state.startLocation);
         let renderedEndLocs = [];
         if(this.state.startLocation !== "") {
             return (

--- a/diplomacy/web/src/gui/pages/content_game.jsx
+++ b/diplomacy/web/src/gui/pages/content_game.jsx
@@ -506,13 +506,14 @@ export class ContentGame extends React.Component {
             .then(() => {
                 // when we get the message response, handle dealing with the gloss state
                 if (message.gloss) {
+                    // we just store the message in local state, it doesn't end up
+                    // in the sortedDict with all the other messages (see game.js addMessage)
                     this.setState({
                         gloss: true, glossMessage: JSON.parse(message.time_sent).message
                     });
                 } else if (!message.gloss) {
                     // or clear it if it isn't a gloss message
                     this.setState({ gloss: null, glossMessage: null });
-                    engine.messages.clearGloss();
                 }
 
                 page.load(


### PR DESCRIPTION
In new games, messages were disappearing or showing up in weird order. This was due to the glossed messages we were adding to the Message sortedDict (the custom data storage for all the game's messages) getting sorted in an unexpected way - instead of ending up at the bottom of the sorting due to their timestamp showing up as `NaN`, they were keeping their position in the list and messing with the rest of the messages. This caused problems when we tried to remove the glossed messages, and messed up the display order of the existing messages.

Now that we're handling glossed messages a little better in content_game, it turns out we don't need to store them in the Message sortedDict at all. We're already keeping track of the glossed message content in content_game local state, so if we just skip adding the message to the dict altogether, we avoid the whole problem explained above. 

This PR should fix all the weird messaging issues that were resulting from this. 