### PR TITLE
Let there be CIVIL DISORDER

### DIFF
--- a/diplomacy/web/src/gui/wizards/gameCreation/gameCreationWizard.js
+++ b/diplomacy/web/src/gui/wizards/gameCreation/gameCreationWizard.js
@@ -58,6 +58,8 @@ export class GameCreationWizard extends React.Component {
             if (!this.state.deadline) {
                 rules.push('NO_DEADLINE');
                 rules.push('REAL_TIME');
+            } else {
+                rules.push('CIVIL_DISORDER');
             }
             this.props.onSubmit({
                 game_id: this.state.game_id,


### PR DESCRIPTION
Created games with set deadline follow CIVIL_DISORDER game rules. Verified at least the first paragraph, which assumes the easiest scenarios.

![20220425_144217](https://user-images.githubusercontent.com/1967061/165337068-6efb1e6f-9cf0-43ad-acc9-5e60bc303e1d.jpg)

UI requests games with CIVIL_DISORDER rule by default- if the game has deadlines**
Else- without deadlines means we have no way of determining that there are inactive players, and can't do anything about it..

## Notes
I think we don't need server updates here- the only scenario where that would be needed is if the rules can be changed after the game as been created/started. Is this possible?